### PR TITLE
Cost calculator function addition

### DIFF
--- a/appsamurai.py
+++ b/appsamurai.py
@@ -8,7 +8,7 @@ def json_cost_calculator(obj):
     def json_flattener(v, flattened_key=''):
         if isinstance(v, dict):
             for k, v2 in v.items():
-                if k == "items":
+                if k == "items" or k == "item":
                     p2 = "{}{}".format(flattened_key, '')
                 else:
                     p2 = "{}/{}".format(flattened_key, k)
@@ -25,13 +25,24 @@ def json_cost_calculator(obj):
 
 
 def to_list(flat_list):
-    dict = {}
+    old_dict = {}
+    sorted_dict = {}
     for i in range(len(flat_list)):
         if "count" in flat_list[i][0]:
-            dict["0" + str(flat_list[i][0].split('/')[0])] = [flat_list[i][1], 0]
+            old_dict["0" + str(flat_list[i][0].split('/')[0])] = [flat_list[i][1], 0]
         elif "price" in flat_list[i][0]:
-            dict["0" + str(flat_list[i][0].split('/')[0])][1] = flat_list[i][1]
-    return dict
+            old_dict["0" + str(flat_list[i][0].split('/')[0])][1] = flat_list[i][1]
+    for k in sorted(old_dict, key=len, reverse=True):
+        sorted_dict[k] = old_dict[k]
+    return sorted_dict
+
+def cost_calculator(sorted_dict):
+    for key, value in sorted_dict.copy().items():
+        if value[1] != 0 and key != "0":
+            parent_key = key[:-1]
+            sorted_dict[parent_key][1] += value[0] * value[1]
+            del sorted_dict[key]
+    return sorted_dict["0"][0] * sorted_dict["0"][1]
 
 
 if __name__ == "__main__":
@@ -41,4 +52,4 @@ if __name__ == "__main__":
         requests.get("https://prod-storyly-media.s3.eu-west-1.amazonaws.com/test-scenarios/sample_2.json").content)
     sample3 = json.loads(
         requests.get("https://prod-storyly-media.s3.eu-west-1.amazonaws.com/test-scenarios/sample_3.json").content)
-    print(to_list(json_cost_calculator(sample2)))
+    print(cost_calculator(to_list(json_cost_calculator(sample3))))


### PR DESCRIPTION
Firstly I changed to_list function a little bit. When I was trying to build a logic to write a function that calculates cost, I realized that I should calculate "price" x "count" and store it in it's ancestor and delete the calculated dictionary element. When dictionary was unordered and I delete element that has children it possibly will gave me error and I wont be able to calculate costs in one iteration. I gave an ability to 'to_list' function so it orders dictionary in length of indexes.Therefore I can calculate costs like level order traversal. In cost_calculator function it takes a sorted dictionary as an argument and it checks whether key has a price of nonzero. When an element has nonzero price it multiplies with count, stores price in ancestor of that key and deletes calculated element. I made a one more key check to 'json_flattener' function since when I was testing given json files, I found that in sample_3.json some of attribute names given as 'item' instead of 'items'.